### PR TITLE
Standardize resource ID parameters to use --id flag

### DIFF
--- a/cmd/command_test.go
+++ b/cmd/command_test.go
@@ -33,9 +33,9 @@ func TestInstanceCommand(t *testing.T) {
 	assert.Contains(t, commandNames, "create")
 	assert.Contains(t, commandNames, "list")
 	assert.Contains(t, commandNames, "get --id <id>")
-	assert.Contains(t, commandNames, "update <id>")
-	assert.Contains(t, commandNames, "delete <id>")
-	assert.Contains(t, commandNames, "resize <id>")
+	assert.Contains(t, commandNames, "update --id <id>")
+	assert.Contains(t, commandNames, "delete --id <id>")
+	assert.Contains(t, commandNames, "resize --id <id>")
 }
 
 func TestVPCCommand(t *testing.T) {
@@ -54,8 +54,8 @@ func TestVPCCommand(t *testing.T) {
 	assert.Contains(t, commandNames, "create")
 	assert.Contains(t, commandNames, "list")
 	assert.Contains(t, commandNames, "get --id <id>")
-	assert.Contains(t, commandNames, "update <id>")
-	assert.Contains(t, commandNames, "delete <id>")
+	assert.Contains(t, commandNames, "update --id <id>")
+	assert.Contains(t, commandNames, "delete --id <id>")
 }
 
 func TestInstanceCreateCommand_Validation(t *testing.T) {

--- a/cmd/instance_delete.go
+++ b/cmd/instance_delete.go
@@ -11,18 +11,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var forceDelete bool
+var (
+	deleteInstanceID string
+	forceDelete      bool
+)
 
 var instanceDeleteCmd = &cobra.Command{
-	Use:   "delete <id>",
+	Use:   "delete --id <id>",
 	Short: "Delete a CloudAMQP instance",
 	Long: `Delete a CloudAMQP instance permanently.
 
 WARNING: This action cannot be undone. All data will be lost.`,
-	Example: `  cloudamqp instance delete 1234
-  cloudamqp instance delete 1234 --force`,
-	Args:              cobra.ExactArgs(1),
-	ValidArgsFunction: completeInstances,
+	Example: `  cloudamqp instance delete --id 1234
+  cloudamqp instance delete --id 1234 --force`,
+	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 		apiKey, err = getAPIKey()
@@ -30,7 +32,11 @@ WARNING: This action cannot be undone. All data will be lost.`,
 			return fmt.Errorf("failed to get API key: %w", err)
 		}
 
-		instanceID, err := strconv.Atoi(args[0])
+		if deleteInstanceID == "" {
+			return fmt.Errorf("--id is required")
+		}
+
+		instanceID, err := strconv.Atoi(deleteInstanceID)
 		if err != nil {
 			return fmt.Errorf("invalid instance ID: %v", err)
 		}
@@ -64,5 +70,8 @@ WARNING: This action cannot be undone. All data will be lost.`,
 }
 
 func init() {
+	instanceDeleteCmd.Flags().StringVar(&deleteInstanceID, "id", "", "Instance ID (required)")
 	instanceDeleteCmd.Flags().BoolVar(&forceDelete, "force", false, "Skip confirmation prompt")
+	instanceDeleteCmd.MarkFlagRequired("id")
+	instanceDeleteCmd.RegisterFlagCompletionFunc("id", completeInstances)
 }

--- a/cmd/vpc_delete.go
+++ b/cmd/vpc_delete.go
@@ -11,18 +11,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var forceDeleteVPC bool
+var (
+	deleteVPCID    string
+	forceDeleteVPC bool
+)
 
 var vpcDeleteCmd = &cobra.Command{
-	Use:   "delete <id>",
+	Use:   "delete --id <id>",
 	Short: "Delete a CloudAMQP VPC",
 	Long: `Delete a CloudAMQP VPC permanently.
 
 WARNING: This action cannot be undone. All instances in the VPC must be deleted first.`,
-	Example: `  cloudamqp vpc delete 5678
-  cloudamqp vpc delete 5678 --force`,
-	Args:              cobra.ExactArgs(1),
-	ValidArgsFunction: completeVPCArgs,
+	Example: `  cloudamqp vpc delete --id 5678
+  cloudamqp vpc delete --id 5678 --force`,
+	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 		apiKey, err = getAPIKey()
@@ -30,7 +32,11 @@ WARNING: This action cannot be undone. All instances in the VPC must be deleted 
 			return fmt.Errorf("failed to get API key: %w", err)
 		}
 
-		vpcID, err := strconv.Atoi(args[0])
+		if deleteVPCID == "" {
+			return fmt.Errorf("--id is required")
+		}
+
+		vpcID, err := strconv.Atoi(deleteVPCID)
 		if err != nil {
 			return fmt.Errorf("invalid VPC ID: %v", err)
 		}
@@ -64,5 +70,8 @@ WARNING: This action cannot be undone. All instances in the VPC must be deleted 
 }
 
 func init() {
+	vpcDeleteCmd.Flags().StringVar(&deleteVPCID, "id", "", "VPC ID (required)")
 	vpcDeleteCmd.Flags().BoolVar(&forceDeleteVPC, "force", false, "Skip confirmation prompt")
+	vpcDeleteCmd.MarkFlagRequired("id")
+	vpcDeleteCmd.RegisterFlagCompletionFunc("id", completeVPCArgs)
 }

--- a/cmd/vpc_update.go
+++ b/cmd/vpc_update.go
@@ -9,22 +9,22 @@ import (
 )
 
 var (
+	updateVPCID   string
 	updateVPCName string
 	updateVPCTags []string
 )
 
 var vpcUpdateCmd = &cobra.Command{
-	Use:   "update <id>",
+	Use:   "update --id <id>",
 	Short: "Update a CloudAMQP VPC",
 	Long: `Update an existing CloudAMQP VPC with new configuration.
 
 You can update the following fields:
   --name: VPC name
   --tags: VPC tags (replaces existing tags)`,
-	Example: `  cloudamqp vpc update 5678 --name=new-vpc-name
-  cloudamqp vpc update 5678 --tags=production --tags=updated`,
-	Args:              cobra.ExactArgs(1),
-	ValidArgsFunction: completeVPCArgs,
+	Example: `  cloudamqp vpc update --id 5678 --name=new-vpc-name
+  cloudamqp vpc update --id 5678 --tags=production --tags=updated`,
+	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 		apiKey, err = getAPIKey()
@@ -32,7 +32,11 @@ You can update the following fields:
 			return fmt.Errorf("failed to get API key: %w", err)
 		}
 
-		vpcID, err := strconv.Atoi(args[0])
+		if updateVPCID == "" {
+			return fmt.Errorf("--id is required")
+		}
+
+		vpcID, err := strconv.Atoi(updateVPCID)
 		if err != nil {
 			return fmt.Errorf("invalid VPC ID: %v", err)
 		}
@@ -60,6 +64,9 @@ You can update the following fields:
 }
 
 func init() {
+	vpcUpdateCmd.Flags().StringVar(&updateVPCID, "id", "", "VPC ID (required)")
 	vpcUpdateCmd.Flags().StringVar(&updateVPCName, "name", "", "New VPC name")
 	vpcUpdateCmd.Flags().StringSliceVar(&updateVPCTags, "tags", []string{}, "New VPC tags")
+	vpcUpdateCmd.MarkFlagRequired("id")
+	vpcUpdateCmd.RegisterFlagCompletionFunc("id", completeVPCArgs)
 }


### PR DESCRIPTION
Changed instance and vpc commands to consistently use --id flag instead of positional arguments for resource identification.