### PR TITLE
Update `cloudamqp instance list` to handle long names

### DIFF
--- a/cmd/instance_list.go
+++ b/cmd/instance_list.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"strconv"
 
 	"cloudamqp-cli/client"
 	"github.com/spf13/cobra"
@@ -32,13 +33,45 @@ var instanceListCmd = &cobra.Command{
 			return nil
 		}
 
+		// Calculate column widths
+		idWidth := len("ID")
+		nameWidth := len("NAME")
+		planWidth := len("PLAN")
+		regionWidth := len("REGION")
+
+		for _, instance := range instances {
+			idLen := len(strconv.Itoa(instance.ID))
+			if idLen > idWidth {
+				idWidth = idLen
+			}
+			if len(instance.Name) > nameWidth {
+				nameWidth = len(instance.Name)
+			}
+			if len(instance.Plan) > planWidth {
+				planWidth = len(instance.Plan)
+			}
+			if len(instance.Region) > regionWidth {
+				regionWidth = len(instance.Region)
+			}
+		}
+
+		// Add padding
+		idWidth += 2
+		nameWidth += 2
+		planWidth += 2
+		regionWidth += 2
+
+		// Create format strings
+		headerFormat := fmt.Sprintf("%%-%ds %%-%ds %%-%ds %%-%ds\n", idWidth, nameWidth, planWidth, regionWidth)
+		rowFormat := fmt.Sprintf("%%-%dd %%-%ds %%-%ds %%-%ds\n", idWidth, nameWidth, planWidth, regionWidth)
+
 		// Print table header
-		fmt.Printf("%-10s %-20s %-15s %-30s\n", "ID", "NAME", "PLAN", "REGION")
-		fmt.Printf("%-10s %-20s %-15s %-30s\n", "--", "----", "----", "------")
+		fmt.Printf(headerFormat, "ID", "NAME", "PLAN", "REGION")
+		fmt.Printf(headerFormat, "--", "----", "----", "------")
 
 		// Print instance data
 		for _, instance := range instances {
-			fmt.Printf("%-10d %-20s %-15s %-30s\n",
+			fmt.Printf(rowFormat,
 				instance.ID,
 				instance.Name,
 				instance.Plan,


### PR DESCRIPTION
This should be fine, names are not allowed to exceed 100 characters.

From Claude:

1. Added dynamic column width calculation: The code now scans through all instances first to determine the maximum width needed for each column (ID, NAME, PLAN, REGION).
2. Added padding: Each column gets an extra 2 spaces of padding for better readability.
3. Dynamic format strings: Instead of using fixed-width format specifiers (like %-20s), the code now generates format strings based on the actual data, ensuring perfect alignment regardless of content length.

Close https://github.com/cloudamqp/cli/issues/10