### PR TITLE
Silence non-JSON output for scripting

### DIFF
--- a/cmd/audit.go
+++ b/cmd/audit.go
@@ -26,7 +26,6 @@ var auditCmd = &cobra.Command{
 
 		csv, err := c.GetAuditLogCSV(auditTimestamp)
 		if err != nil {
-			fmt.Printf("Error getting audit log: %v\n", err)
 			return err
 		}
 

--- a/cmd/instance_account.go
+++ b/cmd/instance_account.go
@@ -37,14 +37,7 @@ var rotatePasswordCmd = &cobra.Command{
 
 		c := client.New(apiKey)
 
-		err = c.RotatePassword(idFlag)
-		if err != nil {
-			fmt.Printf("Error rotating password: %v\n", err)
-			return err
-		}
-
-		fmt.Println("Password rotation initiated successfully.")
-		return nil
+		return c.RotatePassword(idFlag)
 	},
 }
 
@@ -67,16 +60,7 @@ var rotateInstanceAPIKeyCmd = &cobra.Command{
 
 		c := client.New(apiKey)
 
-		err = c.RotateInstanceAPIKey(idFlag)
-		if err != nil {
-			fmt.Printf("Error rotating instance API key: %v\n", err)
-			return err
-		}
-
-		fmt.Println("Instance API key rotation initiated successfully.")
-		fmt.Printf("Warning: The local config for instance %s will need to be updated.\n", idFlag)
-		fmt.Printf("Run 'cloudamqp instance get --id %s' to retrieve and save the new API key.\n", idFlag)
-		return nil
+		return c.RotateInstanceAPIKey(idFlag)
 	},
 }
 

--- a/cmd/instance_actions.go
+++ b/cmd/instance_actions.go
@@ -187,7 +187,6 @@ var upgradeVersionsCmd = &cobra.Command{
 
 		versions, err := c.GetUpgradeVersions(idFlag)
 		if err != nil {
-			fmt.Printf("Error getting upgrade versions: %v\n", err)
 			return err
 		}
 
@@ -196,7 +195,7 @@ var upgradeVersionsCmd = &cobra.Command{
 			return fmt.Errorf("failed to format response: %v", err)
 		}
 
-		fmt.Printf("Upgrade versions:\n%s\n", string(output))
+		fmt.Println(string(output))
 		return nil
 	},
 }
@@ -237,13 +236,7 @@ func performNodeAction(cmd *cobra.Command, action string) error {
 		return fmt.Errorf("unknown action: %s", action)
 	}
 
-	if err != nil {
-		fmt.Printf("Error performing %s: %v\n", action, err)
-		return err
-	}
-
-	fmt.Printf("%s initiated successfully.\n", strings.Title(strings.ReplaceAll(action, "-", " ")))
-	return nil
+	return err
 }
 
 func performClusterAction(cmd *cobra.Command, action string) error {
@@ -271,13 +264,7 @@ func performClusterAction(cmd *cobra.Command, action string) error {
 		return fmt.Errorf("unknown action: %s", action)
 	}
 
-	if err != nil {
-		fmt.Printf("Error performing %s: %v\n", action, err)
-		return err
-	}
-
-	fmt.Printf("%s initiated successfully.\n", strings.Title(strings.ReplaceAll(action, "-", " ")))
-	return nil
+	return err
 }
 
 func performUpgradeAction(cmd *cobra.Command, action, version string) error {
@@ -305,13 +292,7 @@ func performUpgradeAction(cmd *cobra.Command, action, version string) error {
 		return fmt.Errorf("unknown action: %s", action)
 	}
 
-	if err != nil {
-		fmt.Printf("Error performing %s: %v\n", action, err)
-		return err
-	}
-
-	fmt.Printf("%s initiated successfully.\n", strings.Title(strings.ReplaceAll(action, "-", " ")))
-	return nil
+	return err
 }
 
 func performToggleAction(cmd *cobra.Command, action string) error {
@@ -360,17 +341,7 @@ func performToggleAction(cmd *cobra.Command, action string) error {
 		return fmt.Errorf("unknown action: %s", action)
 	}
 
-	if err != nil {
-		fmt.Printf("Error toggling %s: %v\n", action, err)
-		return err
-	}
-
-	status := "disabled"
-	if enable {
-		status = "enabled"
-	}
-	fmt.Printf("%s %s successfully.\n", strings.Title(action), status)
-	return nil
+	return err
 }
 
 func init() {

--- a/cmd/instance_create.go
+++ b/cmd/instance_create.go
@@ -86,7 +86,6 @@ Optional flags:
 
 		resp, err := c.CreateInstance(req)
 		if err != nil {
-			fmt.Printf("Error creating instance: %v\n", err)
 			return err
 		}
 
@@ -97,9 +96,8 @@ Optional flags:
 			}
 
 			if err := waitForInstanceReady(c, resp.ID, timeout); err != nil {
-				// Instance was created but failed to become ready
 				output, _ := json.MarshalIndent(resp, "", "  ")
-				fmt.Printf("Instance created but not ready:\n%s\n", string(output))
+				fmt.Println(string(output))
 				return fmt.Errorf("wait failed: %w", err)
 			}
 		}
@@ -109,7 +107,7 @@ Optional flags:
 			return fmt.Errorf("failed to format response: %v", err)
 		}
 
-		fmt.Printf("Instance created successfully:\n%s\n", string(output))
+		fmt.Println(string(output))
 		return nil
 	},
 }

--- a/cmd/instance_delete.go
+++ b/cmd/instance_delete.go
@@ -58,14 +58,7 @@ WARNING: This action cannot be undone. All data will be lost.`,
 
 		c := client.New(apiKey)
 
-		err = c.DeleteInstance(instanceID)
-		if err != nil {
-			fmt.Printf("Error deleting instance: %v\n", err)
-			return err
-		}
-
-		fmt.Printf("Instance %d deleted successfully.\n", instanceID)
-		return nil
+		return c.DeleteInstance(instanceID)
 	},
 }
 

--- a/cmd/instance_get.go
+++ b/cmd/instance_get.go
@@ -1,9 +1,9 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
-	"strings"
 
 	"cloudamqp-cli/client"
 	"github.com/spf13/cobra"
@@ -35,22 +35,15 @@ var instanceGetCmd = &cobra.Command{
 
 		instance, err := c.GetInstance(instanceID)
 		if err != nil {
-			fmt.Printf("Error getting instance: %v\n", err)
 			return err
 		}
 
-		// Format output as "Name = Value"
-		fmt.Printf("Name = %s\n", instance.Name)
-		fmt.Printf("Plan = %s\n", instance.Plan)
-		fmt.Printf("Region = %s\n", instance.Region)
-		fmt.Printf("Tags = %s\n", strings.Join(instance.Tags, ","))
-		fmt.Printf("Hostname = %s\n", instance.HostnameExternal)
-		ready := "No"
-		if instance.Ready {
-			ready = "Yes"
+		output, err := json.MarshalIndent(instance, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to format response: %v", err)
 		}
-		fmt.Printf("Ready = %s\n", ready)
 
+		fmt.Println(string(output))
 		return nil
 	},
 }

--- a/cmd/instance_list.go
+++ b/cmd/instance_list.go
@@ -26,7 +26,6 @@ var instanceListCmd = &cobra.Command{
 
 		instances, err := c.ListInstances()
 		if err != nil {
-			fmt.Printf("Error listing instances: %v\n", err)
 			return err
 		}
 

--- a/cmd/instance_nodes.go
+++ b/cmd/instance_nodes.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 
@@ -41,7 +42,6 @@ var instanceNodesListCmd = &cobra.Command{
 
 		nodes, err := c.ListNodes(idFlag)
 		if err != nil {
-			fmt.Printf("Error listing nodes: %v\n", err)
 			return err
 		}
 
@@ -97,13 +97,15 @@ var instanceNodesVersionsCmd = &cobra.Command{
 
 		versions, err := c.GetAvailableVersions(idFlag)
 		if err != nil {
-			fmt.Printf("Error getting available versions: %v\n", err)
 			return err
 		}
 
-		fmt.Printf("Available versions:\n")
-		fmt.Printf("RabbitMQ versions: %v\n", versions.RabbitMQVersions)
-		fmt.Printf("Erlang versions: %v\n", versions.ErlangVersions)
+		output, err := json.MarshalIndent(versions, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to format response: %v", err)
+		}
+
+		fmt.Println(string(output))
 		return nil
 	},
 }

--- a/cmd/instance_plugins.go
+++ b/cmd/instance_plugins.go
@@ -41,7 +41,6 @@ var instancePluginsListCmd = &cobra.Command{
 
 		plugins, err := c.ListPlugins(idFlag)
 		if err != nil {
-			fmt.Printf("Error listing plugins: %v\n", err)
 			return err
 		}
 
@@ -86,14 +85,7 @@ var instancePluginsEnableCmd = &cobra.Command{
 
 		c := client.New(apiKey)
 
-		err = c.EnablePlugin(idFlag, pluginName)
-		if err != nil {
-			fmt.Printf("Error enabling plugin '%s': %v\n", pluginName, err)
-			return err
-		}
-
-		fmt.Printf("Plugin '%s' enabled successfully.\n", pluginName)
-		return nil
+		return c.EnablePlugin(idFlag, pluginName)
 	},
 }
 
@@ -118,14 +110,7 @@ var instancePluginsDisableCmd = &cobra.Command{
 
 		c := client.New(apiKey)
 
-		err = c.DisablePlugin(idFlag, pluginName)
-		if err != nil {
-			fmt.Printf("Error disabling plugin '%s': %v\n", pluginName, err)
-			return err
-		}
-
-		fmt.Printf("Plugin '%s' disabled successfully.\n", pluginName)
-		return nil
+		return c.DisablePlugin(idFlag, pluginName)
 	},
 }
 

--- a/cmd/instance_resize.go
+++ b/cmd/instance_resize.go
@@ -64,17 +64,7 @@ Available disk sizes: 0, 25, 50, 100, 250, 500, 1000, 2000 GB`,
 			AllowDowntime: allowDowntime,
 		}
 
-		err = c.ResizeInstanceDisk(instanceID, req)
-		if err != nil {
-			fmt.Printf("Error resizing instance disk: %v\n", err)
-			return err
-		}
-
-		fmt.Printf("Disk resize initiated for instance %d. Additional disk size: %d GB\n", instanceID, diskSize)
-		if allowDowntime {
-			fmt.Println("Note: Downtime is allowed for this resize operation.")
-		}
-		return nil
+		return c.ResizeInstanceDisk(instanceID, req)
 	},
 }
 

--- a/cmd/instance_update.go
+++ b/cmd/instance_update.go
@@ -56,14 +56,7 @@ You can update the following fields:
 			return fmt.Errorf("at least one field must be specified for update")
 		}
 
-		err = c.UpdateInstance(instanceID, req)
-		if err != nil {
-			fmt.Printf("Error updating instance: %v\n", err)
-			return err
-		}
-
-		fmt.Printf("Instance %d updated successfully.\n", instanceID)
-		return nil
+		return c.UpdateInstance(instanceID, req)
 	},
 }
 

--- a/cmd/plans.go
+++ b/cmd/plans.go
@@ -28,7 +28,6 @@ var plansCmd = &cobra.Command{
 
 		plans, err := c.ListPlans(backendFilter)
 		if err != nil {
-			fmt.Printf("Error listing plans: %v\n", err)
 			return err
 		}
 

--- a/cmd/regions.go
+++ b/cmd/regions.go
@@ -27,7 +27,6 @@ var regionsCmd = &cobra.Command{
 
 		regions, err := c.ListRegions(providerFilter)
 		if err != nil {
-			fmt.Printf("Error listing regions: %v\n", err)
 			return err
 		}
 

--- a/cmd/rotate_key.go
+++ b/cmd/rotate_key.go
@@ -24,7 +24,6 @@ var rotateKeyCmd = &cobra.Command{
 
 		resp, err := c.RotateAPIKey()
 		if err != nil {
-			fmt.Printf("Error rotating API key: %v\n", err)
 			return err
 		}
 
@@ -33,14 +32,10 @@ var rotateKeyCmd = &cobra.Command{
 			return fmt.Errorf("failed to format response: %v", err)
 		}
 
-		fmt.Printf("API key rotated successfully:\n%s\n", string(output))
+		fmt.Println(string(output))
 
 		// Update local config file with new key
-		if err := saveAPIKey(resp.APIKey); err != nil {
-			fmt.Printf("Warning: Could not update local config file: %v\n", err)
-		} else {
-			fmt.Printf("Local config file updated with new API key.\n")
-		}
+		_ = saveAPIKey(resp.APIKey)
 
 		return nil
 	},

--- a/cmd/team_invite.go
+++ b/cmd/team_invite.go
@@ -40,7 +40,6 @@ Default role: member`,
 
 		resp, err := c.InviteTeamMember(req)
 		if err != nil {
-			fmt.Printf("Error inviting team member: %v\n", err)
 			return err
 		}
 
@@ -49,7 +48,7 @@ Default role: member`,
 			return fmt.Errorf("failed to format response: %v", err)
 		}
 
-		fmt.Printf("Team member invited:\n%s\n", string(output))
+		fmt.Println(string(output))
 		return nil
 	},
 }

--- a/cmd/team_list.go
+++ b/cmd/team_list.go
@@ -26,7 +26,6 @@ var teamListCmd = &cobra.Command{
 
 		members, err := c.ListTeamMembers()
 		if err != nil {
-			fmt.Printf("Error listing team members: %v\n", err)
 			return err
 		}
 

--- a/cmd/team_remove.go
+++ b/cmd/team_remove.go
@@ -26,7 +26,6 @@ var teamRemoveCmd = &cobra.Command{
 
 		resp, err := c.RemoveTeamMember(removeEmail)
 		if err != nil {
-			fmt.Printf("Error removing team member: %v\n", err)
 			return err
 		}
 
@@ -35,7 +34,7 @@ var teamRemoveCmd = &cobra.Command{
 			return fmt.Errorf("failed to format response: %v", err)
 		}
 
-		fmt.Printf("Team member removed:\n%s\n", string(output))
+		fmt.Println(string(output))
 		return nil
 	},
 }

--- a/cmd/team_update.go
+++ b/cmd/team_update.go
@@ -42,7 +42,6 @@ Available roles: admin, devops, member, monitor, billing manager`,
 
 		resp, err := c.UpdateTeamMember(updateUserID, req)
 		if err != nil {
-			fmt.Printf("Error updating team member: %v\n", err)
 			return err
 		}
 
@@ -51,7 +50,7 @@ Available roles: admin, devops, member, monitor, billing manager`,
 			return fmt.Errorf("failed to format response: %v", err)
 		}
 
-		fmt.Printf("Team member updated:\n%s\n", string(output))
+		fmt.Println(string(output))
 		return nil
 	},
 }

--- a/cmd/vpc_create.go
+++ b/cmd/vpc_create.go
@@ -47,7 +47,6 @@ Optional flags:
 
 		resp, err := c.CreateVPC(req)
 		if err != nil {
-			fmt.Printf("Error creating VPC: %v\n", err)
 			return err
 		}
 
@@ -56,7 +55,7 @@ Optional flags:
 			return fmt.Errorf("failed to format response: %v", err)
 		}
 
-		fmt.Printf("VPC created successfully:\n%s\n", string(output))
+		fmt.Println(string(output))
 		return nil
 	},
 }

--- a/cmd/vpc_delete.go
+++ b/cmd/vpc_delete.go
@@ -58,14 +58,7 @@ WARNING: This action cannot be undone. All instances in the VPC must be deleted 
 
 		c := client.New(apiKey)
 
-		err = c.DeleteVPC(vpcID)
-		if err != nil {
-			fmt.Printf("Error deleting VPC: %v\n", err)
-			return err
-		}
-
-		fmt.Printf("VPC %d deleted successfully.\n", vpcID)
-		return nil
+		return c.DeleteVPC(vpcID)
 	},
 }
 

--- a/cmd/vpc_get.go
+++ b/cmd/vpc_get.go
@@ -35,7 +35,6 @@ var vpcGetCmd = &cobra.Command{
 
 		vpc, err := c.GetVPC(vpcID)
 		if err != nil {
-			fmt.Printf("Error getting VPC: %v\n", err)
 			return err
 		}
 
@@ -44,7 +43,7 @@ var vpcGetCmd = &cobra.Command{
 			return fmt.Errorf("failed to format response: %v", err)
 		}
 
-		fmt.Printf("VPC details:\n%s\n", string(output))
+		fmt.Println(string(output))
 		return nil
 	},
 }

--- a/cmd/vpc_list.go
+++ b/cmd/vpc_list.go
@@ -26,7 +26,6 @@ var vpcListCmd = &cobra.Command{
 
 		vpcs, err := c.ListVPCs()
 		if err != nil {
-			fmt.Printf("Error listing VPCs: %v\n", err)
 			return err
 		}
 

--- a/cmd/vpc_update.go
+++ b/cmd/vpc_update.go
@@ -52,14 +52,7 @@ You can update the following fields:
 			return fmt.Errorf("at least one field must be specified for update")
 		}
 
-		err = c.UpdateVPC(vpcID, req)
-		if err != nil {
-			fmt.Printf("Error updating VPC: %v\n", err)
-			return err
-		}
-
-		fmt.Printf("VPC %d updated successfully.\n", vpcID)
-		return nil
+		return c.UpdateVPC(vpcID, req)
 	},
 }
 

--- a/cmd/wait.go
+++ b/cmd/wait.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	"cloudamqp-cli/client"
@@ -27,8 +26,6 @@ func waitForInstanceReady(c *client.Client, instanceID int, timeout time.Duratio
 		return nil
 	}
 
-	fmt.Fprintf(os.Stderr, "Waiting for instance %d to be ready...\n", instanceID)
-
 	for {
 		select {
 		case <-ctx.Done():
@@ -39,15 +36,9 @@ func waitForInstanceReady(c *client.Client, instanceID int, timeout time.Duratio
 			if err != nil {
 				return fmt.Errorf("failed to check instance status: %w", err)
 			}
-
 			if instance.Ready {
-				elapsed := time.Since(startTime)
-				fmt.Fprintf(os.Stderr, "Instance is ready! (took %s)\n", elapsed.Round(time.Second))
 				return nil
 			}
-
-			elapsed := time.Since(startTime)
-			fmt.Fprintf(os.Stderr, "Still waiting... (elapsed: %s)\n", elapsed.Round(time.Second))
 		}
 	}
 }


### PR DESCRIPTION
Remove progress, success, and error messages from stdout. Commands now output only JSON or nothing, using exit codes for errors.