### PR TITLE
return connection string when using `instance get`

### DIFF
--- a/cmd/instance_get.go
+++ b/cmd/instance_get.go
@@ -16,15 +16,7 @@ func maskPassword(urlStr string) string {
 		return urlStr
 	}
 
-	if parsedURL.User == nil {
-		return urlStr
-	}
-
-	password, hasPassword := parsedURL.User.Password()
-	if !hasPassword || password == "" {
-		return urlStr
-	}
-
+	password, _ := parsedURL.User.Password()
 	return strings.Replace(urlStr, password, "****", 1)
 }
 


### PR DESCRIPTION
When looking up an instance it would be nice to instantly get the connection string. this is returned in terraform and would be nice to get from here as well. 

since value is sensitive, will need an additional flag to show password.

addressing https://github.com/cloudamqp/cli/issues/37 